### PR TITLE
klangk-jit-pool: extract role module, run pool on thinknix52 too

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -198,6 +198,10 @@
           system = "x86_64-linux";
         }
         {
+          hostname = "klangk-jit52";
+          system = "x86_64-linux";
+        }
+        {
           hostname = "arctor";
           system = "x86_64-linux";
         }

--- a/hosts/keithmoon.nix
+++ b/hosts/keithmoon.nix
@@ -26,6 +26,7 @@
     ./roles/mailrelayer.nix
     ./roles/zedalerts.nix
     ./roles/journalwatch.nix
+    ./roles/klangk-jit-pool.nix
     ./roles/klangk-jit-pool-sudo.nix
     ./roles/nvidiapassthru.nix
     ./roles/dictation.nix
@@ -574,10 +575,8 @@
   };
 
   # klangk CI now runs on the klangk-ci VM (two runners, label "nix"); the
-  # host-side runner was retired when the VM proved green.
-  age.secrets."github-runner-klangk" = {
-    file = ../secrets/github-runner-klangk.age;
-  };
+  # host-side runner was retired when the VM proved green. The PAT secret
+  # itself lives in roles/klangk-jit-pool.nix now.
 
   # Autostart the klangk-ci VM at boot (system-level unit, independent of
   # any login session). The VM closure is resolved at NixOS evaluation time
@@ -619,49 +618,13 @@
 
   # klangk JIT runner pool: polls for queued e2e jobs (label "nix") and
   # boots one disposable klangk-jit VM per job with a just-in-time runner
-  # token. Replaces the long-lived klangk-ci VM above. The pool script and
-  # the VM closure are resolved at evaluation time; the PAT comes from the
-  # same agenix secret the old runner module used.
-  systemd.services.klangk-jit-pool =
-    let
-      vmClosure = inputs.self.nixosConfigurations.klangk-jit.config.system.build.vm;
-      poolScript = pkgs.writeShellScript "klangk-jit-pool" (
-        builtins.replaceStrings
-          [
-            "@vmClosure@"
-            "@tokenFile@"
-          ]
-          [
-            "${vmClosure}"
-            "${config.age.secrets."github-runner-klangk".path}"
-          ]
-          (builtins.readFile ../scripts/klangk-jit-pool.sh)
-      );
-    in
-    {
-      description = "klangk JIT ephemeral runner pool (per-job VMs)";
-      after = [
-        "network-online.target"
-        "libvirtd.service"
-      ];
-      wants = [ "network-online.target" ];
-      wantedBy = [ "multi-user.target" ];
-      # jq/curl/qemu-img/flock for the pool; the VM run script needs qemu & co.
-      path = with pkgs; [
-        curl
-        jq
-        qemu_kvm
-        util-linux
-      ];
-      serviceConfig = {
-        Type = "simple";
-        ExecStart = "${poolScript}";
-        StateDirectory = "klangk-jit-pool";
-        RuntimeDirectory = "klangk-jit-pool";
-        Restart = "always";
-        RestartSec = 10;
-      };
-    };
+  # token. Replaces the long-lived klangk-ci VM above. The pool service
+  # and the PAT secret are defined in roles/klangk-jit-pool.nix;
+  # thinknix52 runs the same role with two laptop-sized klangk-jit52 VMs.
+  services.klangk-jit-pool = {
+    enable = true;
+    maxVms = 4;
+  };
 
   environment.etc."security/limits.conf".text = ''
     # set soft and hard nofile for all users

--- a/hosts/klangk-jit52.nix
+++ b/hosts/klangk-jit52.nix
@@ -1,0 +1,25 @@
+# NixOS VM "klangk-jit52" — laptop-sized klangk-jit variant.
+#
+# thinknix52's JIT pool (roles/klangk-jit-pool.nix) boots one fresh copy
+# of this VM per queued e2e job, exactly like keithmoon's pool does with
+# klangk-jit — but sized for a ThinkPad P52 host (6c/12t) that also runs
+# a desktop: fewer cores and less RAM per VM. Everything else (one-shot
+# JIT registration, rootless podman, host-store/tarball-cache 9p
+# sharing) is inherited from klangk-jit.nix.
+{
+  lib,
+  ...
+}:
+
+{
+  imports = [ ./klangk-jit.nix ];
+
+  networking.hostName = lib.mkForce "klangk-jit52";
+  networking.hostId = lib.mkForce "44194a30";
+
+  # P52 sizing: leave the host enough of its 6c/12t to stay usable while
+  # CI runs. Bump memorySize (and maxVms) if this machine has >= 64G.
+  virtualisation.cores = lib.mkForce 6;
+  virtualisation.memorySize = lib.mkForce 16384;
+  virtualisation.diskSize = lib.mkForce 51200;
+}

--- a/hosts/roles/klangk-jit-pool.nix
+++ b/hosts/roles/klangk-jit-pool.nix
@@ -1,0 +1,107 @@
+# klangk JIT runner pool: polls GitHub Actions for queued klangk e2e jobs
+# (label "nix") and boots one disposable klangk-jit VM per job with a
+# just-in-time runner token. Replaces the long-lived multi-runner
+# klangk-ci VM (kept in keithmoon.nix for rollback). The pool script
+# (../../scripts/klangk-jit-pool.sh) and the VM closure are resolved at
+# evaluation time; the PAT comes from the github-runner-klangk agenix
+# secret (must list this host's key in secrets/secrets.nix).
+#
+# Multiple hosts may run this role against the same job queue: each pool
+# names its JIT runners with its own runnerNamePrefix (so stale-runner
+# pruning never touches another host's registrations) and the script
+# kills runners that booted but lost the assignment race after 10 idle
+# minutes.
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}:
+
+let
+  cfg = config.services.klangk-jit-pool;
+in
+{
+  options.services.klangk-jit-pool = {
+    enable = lib.mkEnableOption "klangk JIT ephemeral runner pool (per-job VMs)";
+
+    maxVms = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 4;
+      description = "Maximum concurrent per-job VMs (i.e. runner slots).";
+    };
+
+    vmHost = lib.mkOption {
+      type = lib.types.str;
+      default = "klangk-jit";
+      description = ''
+        nixosConfiguration name of the disposable runner VM this pool boots.
+        Hosts with less RAM/cores can point this at a resized klangk-jit
+        variant (see hosts/klangk-jit52.nix).
+      '';
+    };
+
+    runnerNamePrefix = lib.mkOption {
+      type = lib.types.str;
+      default = "jit";
+      description = ''
+        GitHub runner names are "''${prefix}-vm-<timestamp>-<pid>-<rand>".
+        Stale-runner pruning only ever deletes runners matching this
+        host's prefix, so each pool host needs its own.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    age.secrets."github-runner-klangk" = {
+      file = ../../secrets/github-runner-klangk.age;
+    };
+
+    systemd.services.klangk-jit-pool =
+      let
+        vm = inputs.self.nixosConfigurations.${cfg.vmHost}.config;
+        poolScript = pkgs.writeShellScript "klangk-jit-pool" (
+          builtins.replaceStrings
+            [
+              "@vmRun@"
+              "@tokenFile@"
+              "@maxVms@"
+              "@runnerPrefix@"
+            ]
+            [
+              "${vm.system.build.vm}/bin/run-${vm.system.name}-vm"
+              "${config.age.secrets."github-runner-klangk".path}"
+              (toString cfg.maxVms)
+              cfg.runnerNamePrefix
+            ]
+            (builtins.readFile ../../scripts/klangk-jit-pool.sh)
+        );
+      in
+      {
+        description = "klangk JIT ephemeral runner pool (per-job VMs)";
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+        # jq/curl/qemu-img/flock for the pool; the VM run script needs
+        # qemu & co.
+        path = with pkgs; [
+          curl
+          jq
+          qemu_kvm
+          util-linux
+        ];
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${poolScript}";
+          # Per-job qcow2 disks + console logs live under the state dir
+          # (/var/lib — NOT tmpfs, which would bill VM disk writes to RAM);
+          # active-VM bookkeeping under the runtime dir.
+          StateDirectory = "klangk-jit-pool";
+          RuntimeDirectory = "klangk-jit-pool";
+          Restart = "always";
+          RestartSec = 10;
+        };
+      };
+  };
+}

--- a/hosts/thinknix52.nix
+++ b/hosts/thinknix52.nix
@@ -20,6 +20,7 @@
     ./roles/backupsource.nix
     ./roles/tailscale
     ./roles/nvidiapassthru.nix
+    ./roles/klangk-jit-pool.nix
     #./roles/nix-serve-client.nix
     #./roles/rc505
     #./roles/sessile.nix
@@ -47,6 +48,18 @@
 
   # XXX26.05 Quadro P1000 dropped from mainline 595.xx, needs legacy 580.xx
   hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
+
+  # klangk CI: JIT ephemeral runner pool sharing the "nix"-labeled job
+  # queue with keithmoon's pool. Two concurrent laptop-sized VMs
+  # (klangk-jit52); the pool's own runner prefix keeps the two hosts from
+  # pruning each other's registrations, and idle losers of the boot race
+  # are killed after 10 minutes (see scripts/klangk-jit-pool.sh).
+  services.klangk-jit-pool = {
+    enable = true;
+    maxVms = 2;
+    vmHost = "klangk-jit52";
+    runnerNamePrefix = "jit-thinknix52";
+  };
 
   # silence ACPI "errors" at boot shown before NixOS stage 1 output (default
   # is 4)

--- a/scripts/klangk-jit-pool.sh
+++ b/scripts/klangk-jit-pool.sh
@@ -1,28 +1,45 @@
 #!/usr/bin/env bash
-# klangk JIT runner pool (runs as a systemd service on keithmoon).
+# klangk JIT runner pool (systemd service; see hosts/roles/klangk-jit-pool.nix).
 #
 # Polls the GitHub Actions API for queued jobs carrying the "nix" label;
 # boots fresh disposable klangk-jit VMs (up to MAX_VMS) so GitHub can
 # assign jobs to them. The pool does NOT track which job goes to which
 # VM — the JIT runner picks up whatever GitHub assigns.
 #
-# Injected by the NixOS module (substituted at build time):
-#   @vmClosure@  — klangk-jit VM closure (…/bin/run-klangk-jit-vm)
-#   @tokenFile@  — age-secret path holding a PAT with repo administration
+# Multiple hosts may run pools against the same queue. Every runner this
+# pool registers carries RUNNER_PREFIX in its name; prune_stale_runners
+# only ever touches this pool's own runners, and a VM whose runner came
+# online but was never assigned a job (it lost the boot race against
+# another pool's runner) is killed after IDLE_KILL_SECS instead of
+# idling until the hard timeout.
+#
+# Injected by the NixOS role (substituted at build time):
+#   @vmRun@        — full path to the VM closure's run-*-vm script
+#   @tokenFile@    — age-secret path holding a PAT with repo administration
+#   @maxVms@       — pool concurrency cap
+#   @runnerPrefix@ — GitHub runner name prefix for this host's pool
 # Environment (PATH): curl, jq, qemu-img, flock, coreutils.
 set -euo pipefail
 
 REPO="mcdonc/klangk"
 LABEL="nix"
-RUN=/run/klangk-jit-pool
-MAX_VMS=4
+STATE=/var/lib/klangk-jit-pool # persistent: per-job qcow2 disks + console logs
+RUN=/run/klangk-jit-pool # volatile: active-VM bookkeeping
+MAX_VMS="@maxVms@"
 VM_TIMEOUT_SECS=3600 # 60 min hard kill per VM
+IDLE_KILL_SECS=600 # kill online-but-never-assigned runners after 10 min
 POLL_SECS=20
 
-VM_RUN="@vmClosure@/bin/run-klangk-jit-vm"
+VM_RUN="@vmRun@"
 TOKEN_FILE="@tokenFile@"
+PREFIX="@runnerPrefix@"
 
-mkdir -p "$RUN/active"
+mkdir -p "$STATE" "$RUN/active"
+
+# The VM closure 9p-shares the host's nix tarball cache read-only
+# (see klangk-jit.nix); qemu refuses to start if the path is missing.
+mkdir -p /home/chrism/.cache/nix/tarball-cache-v2
+chown chrism:users /home/chrism/.cache/nix/tarball-cache-v2 2>/dev/null || true
 
 api() {
   local method=$1 path=$2 body=${3:-}
@@ -69,23 +86,41 @@ cleanup_vm() {
   fi
   [ -n "$disk" ] && rm -f -- "$disk"
   [ -n "$tmpdir" ] && rm -rf -- "$tmpdir"
+  rm -f -- "$STATE/console-$vmid.log"
   rm -rf -- "$dir"
   echo "pool: reaped VM $vmid (pid $pid)"
 }
 
-# Reap dead or timed-out VMs.
+# True if the VM's runner is registered, connected, and idle ("online"):
+# it came up but was never assigned a job. API errors count as not-idle
+# so a flaky response never kills a healthy VM.
+runner_is_idle() {
+  local runner_id=$1 status
+  [ -n "$runner_id" ] || return 1
+  status=$(api GET "actions/runners/$runner_id" |
+    jq -r '.status // empty' 2>/dev/null) || return 1
+  [ "$status" = "online" ]
+}
+
+# Reap dead, timed-out, or idle-loser VMs.
 reap() {
-  local dir vmid pid started age
+  local dir vmid pid started age runner_id
   for dir in "$RUN/active"/*; do
     [ -d "$dir" ] || continue
     vmid=$(basename "$dir")
     pid=$(cat "$dir/pid" 2>/dev/null || true)
     started=$(cat "$dir/started" 2>/dev/null || echo 0)
     age=$(( $(date +%s) - started ))
+    runner_id=$(cat "$dir/runner_id" 2>/dev/null || true)
 
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
       if [ "$age" -ge "$VM_TIMEOUT_SECS" ]; then
         echo "pool: VM $vmid exceeded ${VM_TIMEOUT_SECS}s; killing pid $pid"
+        kill "$pid" 2>/dev/null || true
+        sleep 2
+        kill -9 "$pid" 2>/dev/null || true
+      elif [ "$age" -ge "$IDLE_KILL_SECS" ] && runner_is_idle "$runner_id"; then
+        echo "pool: VM $vmid runner idle since boot (${age}s; lost assignment race); killing pid $pid"
         kill "$pid" 2>/dev/null || true
         sleep 2
         kill -9 "$pid" 2>/dev/null || true
@@ -104,8 +139,8 @@ boot_vm() {
   ts=$(date +%s)
   vmid="vm-$ts-$$-$RANDOM"
   dir="$RUN/active/$vmid"
-  disk="$RUN/$vmid.qcow2"
-  name="jit-$vmid"
+  disk="$STATE/$vmid.qcow2"
+  name="$PREFIX-$vmid"
 
   mkdir -p "$dir"
 
@@ -129,24 +164,25 @@ boot_vm() {
 
   rm -f -- "$disk"
 
-  tmpdir=$(mktemp -d "$RUN/$vmid.XXXXXX")
+  tmpdir=$(mktemp -d "$STATE/$vmid.XXXXXX")
   mkdir -p "$tmpdir/xchg"
   printf '%s' "$token" >"$tmpdir/xchg/jitconfig"
   cp /nix/var/nix/db/db.sqlite "$tmpdir/xchg/host-nix-db.sqlite"
   printf '%s' "$tmpdir" >"$dir/tmpdir"
 
-  USE_TMPDIR=1 TMPDIR="$tmpdir" NIX_DISK_IMAGE="$disk" "$VM_RUN" >"$RUN/console-$vmid.log" 2>&1 &
+  USE_TMPDIR=1 TMPDIR="$tmpdir" NIX_DISK_IMAGE="$disk" "$VM_RUN" >"$STATE/console-$vmid.log" 2>&1 &
   printf '%s' "$!" >"$dir/pid"
 
   echo "pool: booted $vmid (runner $runner_id, pid $!)"
 }
 
-# Delete offline jit-* runners left over from crashed pools/VMs.
+# Delete offline runners left over from crashed pools/VMs — only those
+# our own prefix (another host's pool may be mid-boot with its own).
 prune_stale_runners() {
   local id name runner_status
   while IFS=$'\t' read -r id name runner_status; do
     [ -n "$id" ] || continue
-    if [ "$runner_status" = "offline" ] && [[ "$name" == jit-* ]]; then
+    if [ "$runner_status" = "offline" ] && [[ "$name" == "$PREFIX"-vm-* ]]; then
       echo "pool: pruning stale runner $name ($id)"
       api DELETE "actions/runners/$id" >/dev/null 2>&1 || true
     fi
@@ -154,7 +190,7 @@ prune_stale_runners() {
     jq -r '.runners[]? | [.id, .name, .status] | @tsv' 2>/dev/null || true)
 }
 
-echo "pool: starting (max $MAX_VMS VMs, poll ${POLL_SECS}s)"
+echo "pool: starting (max $MAX_VMS VMs, prefix $PREFIX, poll ${POLL_SECS}s)"
 prune_stale_runners
 
 while true; do

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -312,6 +312,7 @@ in
   "github-runner-klangk.age".publicKeys = [
     chrism
     keithmoon
+    thinknix52
     klangk-ci
     klangk-ci-bootstrap
   ];


### PR DESCRIPTION
- new hosts/roles/klangk-jit-pool.nix role (enable/maxVms/vmHost/ runnerNamePrefix options); keithmoon keeps a 4-VM pool via the role
- new hosts/klangk-jit52.nix: laptop-sized klangk-jit VM; thinknix52 runs a 2-VM pool (prefix jit-thinknix52) on the same job queue
- script: per-host runner prefixes keep pools from pruning each other's runners; idle boot-race losers killed after 10 min; per-job disks/console logs moved to /var/lib/klangk-jit-pool
- secrets: thinknix52 key added to github-runner-klangk.age